### PR TITLE
Added position option for iOS

### DIFF
--- a/src/ios/PKVideoThumbnail.m
+++ b/src/ios/PKVideoThumbnail.m
@@ -29,7 +29,8 @@
 @implementation PKVideoThumbnail
 
 BOOL extractVideoThumbnail ( NSString *theSourceVideoName,
-                             NSString *theTargetImageName )
+                             NSString *theTargetImageName,
+                             NSInteger thePosition )
 {
 
     UIImage *thumbnail;
@@ -50,10 +51,10 @@ BOOL extractVideoThumbnail ( NSString *theSourceVideoName,
     MPMoviePlayerController *mp = [[MPMoviePlayerController alloc]
       initWithContentURL: url ];
     mp.shouldAutoplay = NO;
-    mp.initialPlaybackTime = 1;
-    mp.currentPlaybackTime = 1;
+    mp.initialPlaybackTime = thePosition;
+    mp.currentPlaybackTime = thePosition;
     // get the thumbnail
-    thumbnail = [mp thumbnailImageAtTime:1
+    thumbnail = [mp thumbnailImageAtTime:thePosition
                              timeOption:MPMovieTimeOptionNearestKeyFrame];
     [mp stop];
 
@@ -70,8 +71,9 @@ BOOL extractVideoThumbnail ( NSString *theSourceVideoName,
     @try {
         NSString* theSourceVideoName = [command.arguments objectAtIndex:0];
         NSString* theTargetImageName = [command.arguments objectAtIndex:1];
+        NSInteger thePosition = [[command.arguments objectAtIndex:2] intValue];
         
-        if ( extractVideoThumbnail(theSourceVideoName, theTargetImageName) )
+        if ( extractVideoThumbnail(theSourceVideoName, theTargetImageName, thePosition) )
         {
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:theTargetImageName];
             javaScript = [pluginResult toSuccessCallbackString:command.callbackId];

--- a/www/PKVideoThumbnail.js
+++ b/www/PKVideoThumbnail.js
@@ -21,13 +21,13 @@
 
 var PKVideoThumbnail = PKVideoThumbnail || {};
 
-PKVideoThumbnail.createThumbnail = function ( source, target, success, failure )
+PKVideoThumbnail.createThumbnail = function ( source, target, position, success, failure )
 {
   console.log ("Attempting to extract the thumbnail from " + source + " and save it to " + target );
   cordova.exec(success, failure,
               "PKVideoThumbnail",
               "createThumbnail",
-              [source, target]);
+              [source, target, position]);
 }
 
 module.exports = PKVideoThumbnail;


### PR DESCRIPTION
Added a position option that allows you to set the position (in seconds) where the thumbnail should be taken. Right now this only works for iOS, but the Javascript interaction will change for both iOS and Android to this:

window.PKVideoThumbnail.createThumbnail ( sourceVideoPath, targetThumbnailPath, position, success, failure );

Position is an integer, so if you pass it something like "2.6", it'll truncate to the integer value, which will be "2". If you need it rounded instead of truncated, do the rounding in Javascript first, then pass the rounded integer to the PKVideoThumbnail library.