### PR TITLE
Update cordova-plugin-file dependency to 6.0.1

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -11,7 +11,7 @@
     <author>Kerri Shotts</author>
     <keywords>video, thumbnail, ios, android</keywords>
     <license>MIT</license>
-    <dependency id="cordova-plugin-file" version="^4.0.0"/>
+    <dependency id="cordova-plugin-file" version="^6.0.1"/>
     <js-module src="www/PKVideoThumbnail.js" name="PKVideoThumbnail">
         <clobbers target="window.PKVideoThumbnail" />
     </js-module>


### PR DESCRIPTION
### Platform affected

- iOS
- Android

### What does this PR do?

Change cordova-plugin-file dependency to `6.0.1`.

This PR solves https://github.com/photokandyStudios/PKVideoThumbnail/issues/17.

### What testing has been done on this change?

Has been added to project and tested on :
- iOS Simulator 11.3
- Android Simulator 8.1